### PR TITLE
Add ARM64 Docker Image Support

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -6,6 +6,10 @@ RUN cd /build && make build
 
 FROM gcr.io/pingcap-public/pingcap/alpine-glibc:alpine-3.14.3
 
+RUN apk update --no-cache && apk add ca-certificates
+
 COPY --from=builder /build/eventrouter /app/eventrouter
+
+USER nobody:nobody
 
 CMD ["/bin/sh", "-c", "/app/eventrouter -v 3 -logtostderr"]

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,23 +1,11 @@
-# Copyright 2017 Heptio Inc.
-#
-# Licensed under the Apache License, Version 2.0 (the "License");
-# you may not use this file except in compliance with the License.
-# You may obtain a copy of the License at
-#
-#    http://www.apache.org/licenses/LICENSE-2.0
-#
-# Unless required by applicable law or agreed to in writing, software
-# distributed under the License is distributed on an "AS IS" BASIS,
-# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-# See the License for the specific language governing permissions and
-# limitations under the License.
+FROM golang:1.16 as builder
 
-FROM alpine:3.9
-MAINTAINER Timothy St. Clair "tstclair@heptio.com"  
+RUN mkdir /build
+COPY . /build
+RUN cd /build && make build
 
-WORKDIR /app
-RUN apk update --no-cache && apk add ca-certificates
-ADD eventrouter /app/
-USER nobody:nobody
+FROM gcr.io/pingcap-public/pingcap/alpine-glibc:alpine-3.14.3
+
+COPY --from=builder /build/eventrouter /app/eventrouter
 
 CMD ["/bin/sh", "-c", "/app/eventrouter -v 3 -logtostderr"]

--- a/Makefile
+++ b/Makefile
@@ -35,6 +35,9 @@ DOCKER_BUILD ?= $(DOCKER) run --rm -v $(DIR):$(BUILDMNT) -w $(BUILDMNT) $(BUILD_
 
 all: container
 
+build:
+	CGO_ENABLED=0 go build
+
 container:
 	$(DOCKER_BUILD) 'CGO_ENABLED=0 go build -mod=vendor'
 	$(DOCKER) build -t $(REGISTRY)/$(TARGET):latest -t $(REGISTRY)/$(TARGET):$(VERSION) .


### PR DESCRIPTION
This PR tries to add support for ARM64, with the help of buildx of docker.

1. Dockerfile is modified for multi-stage building.
2. Necessary changes are make to Makefile to detect arch on different platform.


Should built with:

```
docker buildx build --platform linux/arm64,linux/amd64 -t n0vad3v/eventrouter:v0.4 . --push
```